### PR TITLE
doc: :pencil2: Update splitting-commit.md

### DIFF
--- a/splitting-commit.md
+++ b/splitting-commit.md
@@ -32,7 +32,7 @@ From here we will edit the M2 commit:
 
 ![git rebase -i](splitting-commit/edit-M2.png)
 
-Then, when the rebase script drops you to the command line, you reset that commit, take the changes that have been reset, and create multiple commits out of them. When you save and exit the editor, Git rewinds to the parent of the first commit in your list, applies the first commit (e7f2fe1) and drops you to the console. There, you can do a mixed reset of that commit with `git reset HEAD^`, which effectively undoes that commit and leaves the modified files unstaged. Now you can stage and commit files until you have several commits, and run `git rebase --continue` when you’re done:
+Then, when the rebase script drops you to the command line, you reset that commit, take the changes that have been reset, and create multiple commits out of them. When you save and exit the editor, Git rewinds to the parent of the first commit in your list, applies the first commit (e7f2fe1), applies the second (8d0d74e), and drops you to the console. There, you can do a mixed reset of that commit with `git reset HEAD^`, which effectively undoes that commit and leaves the modified files unstaged. Now you can stage and commit files until you have several commits, and run `git rebase --continue` when you’re done:
 
 ```bash
 git reset HEAD^


### PR DESCRIPTION
Instead of reverting or resetting I am updating the markdown with the  previous text that was removed.